### PR TITLE
Silta container base image migration to Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   cicd74:
     docker:
-      - image: eu.gcr.io/silta-images/cicd:circleci-php7.4-node14-composer2-v0.1
+      - image: wunderio/silta-cicd:circleci-php7.4-node14-composer2-v0.1
 
 workflows:
   version: 2

--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for building nginx.
-FROM eu.gcr.io/silta-images/nginx:latest
+FROM wunderio/silta-nginx:latest
 
 COPY . /app/web
 

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the PHP container.
-FROM eu.gcr.io/silta-images/php:7.4-fpm-v0.1
+FROM wunderio/silta-php-fpm:7.4-fpm-v0.1
 
 COPY --chown=www-data:www-data . /app

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Shell container.
-FROM eu.gcr.io/silta-images/shell:php7.4-v0.1
+FROM wunderio/silta-php-shell:php7.4-v0.1
 
 COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
Silta docker container images are being migrated from [Google Container Registry](https://eu.gcr.io/silta-images/) to [Docker Hub](https://hub.docker.com/u/wunderio).
This PR changes base image location to the new image registry and adjusts some image names.

Please review adjusted image paths and make sure this PR only changes relevant configuration files.

This pull request was created with https://github.com/wunderio/internal-mass-updater.